### PR TITLE
Modify eth tx nonce

### DIFF
--- a/helper/tx.go
+++ b/helper/tx.go
@@ -58,7 +58,7 @@ func GenerateAuthObj(client *ethclient.Client, address common.Address, data []by
 	}
 
 	// fetch nonce
-	nonce, err := client.PendingNonceAt(context.Background(), fromAddress)
+	nonce, err := client.NonceAt(context.Background(), fromAddress, nil)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
Optimize sending transactions using account nonce instead of  account pendding nonce to avoid sending useless transactions.