### PR TITLE
Optimize proposer rotation when meet no-ack

### DIFF
--- a/bridge/setu/processor/checkpoint.go
+++ b/bridge/setu/processor/checkpoint.go
@@ -127,7 +127,7 @@ func (cp *CheckpointProcessor) sendCheckpointToHeimdall(headerBlockStr string) (
 
 	cp.Logger.Info("Processing new header", "headerNumber", header.Number)
 	var isProposer bool
-	if isProposer, err = util.IsProposer(cp.cliCtx); err != nil {
+	if isProposer, err = util.IsProposerByIndex(cp.cliCtx, 0); err != nil {
 		cp.Logger.Error("Error checking isProposer in HeaderBlock handler", "error", err)
 		return err
 	}
@@ -386,8 +386,8 @@ func (cp *CheckpointProcessor) handleCheckpointNoAck() {
 	if isNoAckRequired {
 		var isProposer bool
 
-		if isProposer, err = util.IsInProposerList(cp.cliCtx, count); err != nil {
-			cp.Logger.Error("Error checking IsInProposerList while proposing Checkpoint No-Ack ", "error", err)
+		if isProposer, err = util.IsProposerByIndex(cp.cliCtx, count); err != nil {
+			cp.Logger.Error("Error checking IsProposer while proposing Checkpoint No-Ack ", "error", err)
 			return
 		}
 

--- a/bridge/setu/util/common.go
+++ b/bridge/setu/util/common.go
@@ -86,10 +86,12 @@ func Logger() log.Logger {
 	return logger
 }
 
-// IsProposer  checks if we are proposer
-func IsProposer(cliCtx cliContext.CLIContext) (bool, error) {
+// IsProposer  checks if we are proposer.
+// index starts from 0, and it will return whether it is the current proposer
+// if index = 0.
+func IsProposerByIndex(cliCtx cliContext.CLIContext, index uint64) (bool, error) {
 	var proposers []hmtypes.Validator
-	count := uint64(1)
+	count := index + 1
 	result, err := helper.FetchFromAPI(cliCtx,
 		helper.GetHeimdallServerEndpoint(fmt.Sprintf(ProposersURL, strconv.FormatUint(count, 10))),
 	)
@@ -105,7 +107,13 @@ func IsProposer(cliCtx cliContext.CLIContext) (bool, error) {
 		return false, err
 	}
 
-	if bytes.Equal(proposers[0].Signer.Bytes(), helper.GetAddress()) {
+	proposerSize := len(proposers)
+	if proposerSize == 0 {
+		return false, nil
+	}
+	proposerIndex := index % uint64(proposerSize)
+
+	if bytes.Equal(proposers[proposerIndex].Signer.Bytes(), helper.GetAddress()) {
 		return true, nil
 	}
 


### PR DESCRIPTION
When meet checkpoint no-ack, rotate proposers by skip count to Improve recovery speed.