### PR TITLE
Add general control mechanism

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -11,6 +11,8 @@ linters:
     - wrapcheck
     - gochecknoglobals
     - goerr113
+    - gochecknoinits
+    - exhaustivestruct
 
 service:
   golangci-lint-version: 1.41

--- a/bridge/setu/util/common.go
+++ b/bridge/setu/util/common.go
@@ -25,19 +25,23 @@ import (
 	authTypes "github.com/maticnetwork/heimdall/auth/types"
 	chainManagerTypes "github.com/maticnetwork/heimdall/chainmanager/types"
 	checkpointTypes "github.com/maticnetwork/heimdall/checkpoint/types"
+	featureManagerTypes "github.com/maticnetwork/heimdall/featuremanager/types"
 	"github.com/maticnetwork/heimdall/helper"
 	"github.com/maticnetwork/heimdall/types"
 	hmtypes "github.com/maticnetwork/heimdall/types"
 )
 
 const (
-	AccountDetailsURL         = "/auth/accounts/%v"
-	LastNoAckURL              = "/checkpoints/last-no-ack"
-	CurrentEpochURL           = "/checkpoints/epoch"
-	CheckpointParamsURL       = "/checkpoints/params"
-	CheckpointActivationURL   = "/checkpoints/activation-height/%v"
-	ChainManagerParamsURL     = "/chainmanager/params"
-	ChainNewParamsURL         = "/chainmanager/newparams/%v" //for new eth forkChain such as bsc, replace address of params
+	AccountDetailsURL       = "/auth/accounts/%v"
+	LastNoAckURL            = "/checkpoints/last-no-ack"
+	CurrentEpochURL         = "/checkpoints/epoch"
+	CheckpointParamsURL     = "/checkpoints/params"
+	CheckpointActivationURL = "/checkpoints/activation-height/%v"
+	ChainManagerParamsURL   = "/chainmanager/params"
+	// for new eth forkChain such as bsc, replace address of params.
+	ChainNewParamsURL         = "/chainmanager/newparams/%v"
+	TaragetFeatureConfigURL   = "/featuremanager/target-feature/%v"
+	AllFeatureConfigURL       = "/featuremanager/feature-map"
 	ProposersURL              = "/staking/proposer/%v"
 	BufferedCheckpointURL     = "/checkpoints/buffer/%v"
 	BufferedCheckpointSyncURL = "/checkpoints/sync/%v"
@@ -67,8 +71,10 @@ const (
 	ProposersURLSizeLimit = 100
 )
 
-var logger log.Logger
-var loggerOnce sync.Once
+var (
+	logger     log.Logger
+	loggerOnce sync.Once
+)
 
 // Logger returns logger singleton instance
 func Logger() log.Logger {
@@ -108,7 +114,6 @@ func IsProposerByIndex(cliCtx cliContext.CLIContext, index uint64) (bool, error)
 	result, err := helper.FetchFromAPI(cliCtx,
 		helper.GetHeimdallServerEndpoint(fmt.Sprintf(ProposersURL, strconv.FormatUint(count, 10))),
 	)
-
 	if err != nil {
 		logger.Error("Error fetching proposers", "url", ProposersURL, "error", err)
 		return false, err
@@ -190,7 +195,7 @@ func IsInProposerList(cliCtx cliContext.CLIContext, count uint64) (bool, error) 
 	return false, nil
 }
 
-//default offset 0
+// default offset 0.
 func CalculateTaskDelay(cliCtx cliContext.CLIContext) (bool, time.Duration) {
 	return CalculateTaskDelayWithOffset(cliCtx, 0)
 }
@@ -276,8 +281,8 @@ func IsEventSender(cliCtx cliContext.CLIContext, validatorID uint64) bool {
 	return bytes.Equal(validator.Signer.Bytes(), helper.GetAddress())
 }
 
-//CreateURLWithQuery receives the uri and parameters in key value form
-//it will return the new url with the given query from the parameter
+// CreateURLWithQuery receives the uri and parameters in key value form
+// it will return the new url with the given query from the parameter.
 func CreateURLWithQuery(uri string, param map[string]interface{}) (string, error) {
 	urlObj, err := url.Parse(uri)
 	if err != nil {
@@ -360,7 +365,6 @@ func GetChainmanagerParams(cliCtx cliContext.CLIContext) (*chainManagerTypes.Par
 		cliCtx,
 		helper.GetHeimdallServerEndpoint(ChainManagerParamsURL),
 	)
-
 	if err != nil {
 		logger.Error("Error fetching chainmanager params", "err", err)
 		return nil, err
@@ -381,7 +385,6 @@ func GetNewChainParams(cliCtx cliContext.CLIContext, rootChain string) (*chainMa
 		cliCtx,
 		helper.GetHeimdallServerEndpoint(fmt.Sprintf(ChainNewParamsURL, rootChain)),
 	)
-
 	if err != nil {
 		logger.Error("Error fetching chainmanager params", "root", rootChain, "err", err)
 		return nil, err
@@ -402,7 +405,6 @@ func GetCheckpointParams(cliCtx cliContext.CLIContext) (*checkpointTypes.Params,
 		cliCtx,
 		helper.GetHeimdallServerEndpoint(CheckpointParamsURL),
 	)
-
 	if err != nil {
 		logger.Error("Error fetching Checkpoint params", "err", err)
 		return nil, err
@@ -423,7 +425,6 @@ func GetBufferedCheckpoint(cliCtx cliContext.CLIContext, rootChain string) (*hmt
 		cliCtx,
 		helper.GetHeimdallServerEndpoint(fmt.Sprintf(BufferedCheckpointURL, rootChain)),
 	)
-
 	if err != nil {
 		logger.Debug("Error fetching buffered checkpoint", "err", err)
 		return nil, err
@@ -444,7 +445,6 @@ func GetBufferedCheckpointSync(cliCtx cliContext.CLIContext, rootChain string) (
 		cliCtx,
 		helper.GetHeimdallServerEndpoint(fmt.Sprintf(BufferedCheckpointSyncURL, rootChain)),
 	)
-
 	if err != nil {
 		logger.Debug("Error fetching buffered checkpoint sync", "root", rootChain, "err", err)
 		return nil, err
@@ -465,7 +465,6 @@ func GetlastestCheckpoint(cliCtx cliContext.CLIContext, rootChain string) (*hmty
 		cliCtx,
 		helper.GetHeimdallServerEndpoint(fmt.Sprintf(LatestCheckpointURL, rootChain)),
 	)
-
 	if err != nil {
 		logger.Debug("Error fetching latest checkpoint", "err", err)
 		return nil, err
@@ -496,7 +495,6 @@ func GetNextStakingRecord(cliCtx cliContext.CLIContext, rootChain string) (*stak
 		cliCtx,
 		helper.GetHeimdallServerEndpoint(fmt.Sprintf(NextStakingRecordURL, rootChain)),
 	)
-
 	if err != nil {
 		logger.Debug("Error fetching next stake record", "err", err)
 		return nil, err
@@ -519,7 +517,6 @@ func GetValidatorNonce(cliCtx cliContext.CLIContext, validatorID uint64) (uint64
 	result, err := helper.FetchFromAPI(cliCtx,
 		helper.GetHeimdallServerEndpoint(fmt.Sprintf(ValidatorURL, strconv.FormatUint(validatorID, 10))),
 	)
-
 	if err != nil {
 		logger.Error("Error fetching validator data", "error", err)
 		return 0, 0, err
@@ -534,4 +531,50 @@ func GetValidatorNonce(cliCtx cliContext.CLIContext, validatorID uint64) (uint64
 	logger.Debug("Validator data recieved ", "validator", validator.String())
 
 	return validator.Nonce, result.Height, nil
+}
+
+// GetTargetFeatureConfig return target feature config.
+func GetTargetFeatureConfig(
+	cliCtx cliContext.CLIContext, feature string,
+) (*featureManagerTypes.PlainFeatureData, error) {
+	response, err := helper.FetchFromAPI(
+		cliCtx,
+		helper.GetHeimdallServerEndpoint(fmt.Sprintf(TaragetFeatureConfigURL, feature)),
+	)
+	if err != nil {
+		logger.Error("Error fetching target feature", "feature", feature, "err", err)
+
+		return nil, err
+	}
+
+	var params featureManagerTypes.PlainFeatureData
+	if err := json.Unmarshal(response.Result, &params); err != nil {
+		logger.Error("Error unmarshalling feature data", "feature", feature, "url", TaragetFeatureConfigURL, "err", err)
+
+		return nil, err
+	}
+
+	return &params, nil
+}
+
+// GetFeatureMap return all features in a map.
+func GetFeatureMap(cliCtx cliContext.CLIContext) (*featureManagerTypes.FeatureParams, error) {
+	response, err := helper.FetchFromAPI(
+		cliCtx,
+		helper.GetHeimdallServerEndpoint(AllFeatureConfigURL),
+	)
+	if err != nil {
+		logger.Error("Error fetching feature params", "err", err)
+
+		return nil, err
+	}
+
+	var params featureManagerTypes.FeatureParams
+	if err := json.Unmarshal(response.Result, &params); err != nil {
+		logger.Error("Error unmarshalling feature params", "url", TaragetFeatureConfigURL, "err", err)
+
+		return nil, err
+	}
+
+	return &params, nil
 }

--- a/featuremanager/client/cli/flags.go
+++ b/featuremanager/client/cli/flags.go
@@ -1,0 +1,5 @@
+package cli
+
+const (
+	FlagValidatorID = "validator-id"
+)

--- a/featuremanager/client/cli/parse.go
+++ b/featuremanager/client/cli/parse.go
@@ -1,0 +1,69 @@
+package cli
+
+import (
+	"encoding/json"
+	"io/ioutil"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/maticnetwork/heimdall/featuremanager/types"
+	hmTypes "github.com/maticnetwork/heimdall/types"
+
+	"github.com/cosmos/cosmos-sdk/codec"
+)
+
+type (
+	FeatureChangesJSON []FeatureChangeJSON
+
+	// FeatureChangeJSON defines a parameter change used in JSON input. This
+	// allows values to be specified in raw JSON instead of being string encoded.
+	FeatureChangeJSON struct {
+		Value json.RawMessage `json:"value" yaml:"value"`
+	}
+
+	// FeatureChangeProposalJSON defines a FeatureChangeProposal with a deposit used
+	// to parse parameter change proposals from a JSON file.
+	FeatureChangeProposalJSON struct {
+		Title       string              `json:"title" yaml:"title"`
+		Description string              `json:"description" yaml:"description"`
+		Changes     FeatureChangesJSON  `json:"changes" yaml:"changes"`
+		Deposit     sdk.Coins           `json:"deposit" yaml:"deposit"`
+		Validator   hmTypes.ValidatorID `json:"validator" yaml:"validator"`
+	}
+)
+
+func NewFeatureChangeJSON(value json.RawMessage) FeatureChangeJSON {
+	return FeatureChangeJSON{value}
+}
+
+// ToParamChange converts a FeatureChangeJSON object to ParamChange.
+func (fcj FeatureChangeJSON) ToParamChange() types.FeatureChange {
+	return types.NewFeatureChange(string(fcj.Value))
+}
+
+// ToFeatureChanges converts a slice of FeatureChangeJSON objects to a slice of
+// FeatureChange.
+func (fcj FeatureChangesJSON) ToFeatureChanges() []types.FeatureChange {
+	res := make([]types.FeatureChange, len(fcj))
+	for i, pc := range fcj {
+		res[i] = pc.ToParamChange()
+	}
+
+	return res
+}
+
+// ParseParamChangeProposalJSON reads and parses a ParamChangeProposalJSON from
+// file.
+func ParseFeatureChangeProposalJSON(cdc *codec.Codec, proposalFile string) (FeatureChangeProposalJSON, error) {
+	proposal := FeatureChangeProposalJSON{}
+
+	contents, err := ioutil.ReadFile(proposalFile)
+	if err != nil {
+		return proposal, err
+	}
+
+	if err := cdc.UnmarshalJSON(contents, &proposal); err != nil {
+		return proposal, err
+	}
+
+	return proposal, nil
+}

--- a/featuremanager/client/cli/query.go
+++ b/featuremanager/client/cli/query.go
@@ -1,0 +1,112 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/client/context"
+	"github.com/cosmos/cosmos-sdk/codec"
+	"github.com/maticnetwork/heimdall/featuremanager/types"
+	"github.com/maticnetwork/heimdall/version"
+	"github.com/spf13/cobra"
+)
+
+// GetQueryCmd returns the transaction commands for this module.
+func GetQueryCmd(cdc *codec.Codec) *cobra.Command {
+	txCmd := &cobra.Command{
+		Use:                types.ModuleName,
+		Short:              "Querying commands for the featuremanager module",
+		DisableFlagParsing: true,
+		RunE:               client.ValidateCmd,
+	}
+	txCmd.AddCommand(
+		client.GetCommands(
+			GetTargetFeature(cdc),
+			GetAllFeatures(cdc),
+		)...,
+	)
+
+	return txCmd
+}
+
+// GetTargetFeature implements the target-feature query command.
+func GetTargetFeature(cdc *codec.Codec) *cobra.Command {
+	//nolint: exhaustivestruct
+	return &cobra.Command{
+		Use:   "target-feature [target feature]",
+		Short: "show the current featuremanager target feature information in proposal",
+		Long: strings.TrimSpace(
+			fmt.Sprintf(
+				`Query values set as chain manager parameters.
+Example:
+$ %s query featuremanager target-features
+`,
+				version.ClientName,
+			),
+		),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cliCtx := context.NewCLIContext().WithCodec(cdc)
+
+			if len(args) != 1 {
+				return fmt.Errorf(`expect an arg to figure out feature name:
+				%s query featuremanager target-feature <target feature>`, version.ClientName)
+			}
+
+			route := fmt.Sprintf("custom/%s/%s", types.QuerierRoute, types.QueryTargetFeature)
+
+			qp, _ := cliCtx.Codec.MarshalJSON(types.QueryTargetFeatureParam{
+				TargetFeature: args[0],
+			})
+
+			data, _, err := cliCtx.QueryWithData(route, qp)
+			if err != nil {
+				return err
+			}
+
+			var params types.PlainFeatureData
+			if err = json.Unmarshal(data, &params); err != nil {
+				return err
+			}
+
+			return cliCtx.PrintOutput(params)
+		},
+	}
+}
+
+// GetAllFeatures implements the all-features query command.
+func GetAllFeatures(cdc *codec.Codec) *cobra.Command {
+	//nolint: exhaustivestruct
+	return &cobra.Command{
+		Use:   "all-features",
+		Args:  cobra.NoArgs,
+		Short: "show the current featuremanager parameters information in proposal",
+		Long: strings.TrimSpace(
+			fmt.Sprintf(
+				`Query values set as chain manager parameters.
+Example:
+$ %s query featuremanager all-features
+`,
+				version.ClientName,
+			),
+		),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cliCtx := context.NewCLIContext().WithCodec(cdc)
+
+			route := fmt.Sprintf("custom/%s/%s", types.QuerierRoute, types.QueryFeatureMap)
+
+			data, _, err := cliCtx.QueryWithData(route, nil)
+			if err != nil {
+				return err
+			}
+
+			var params types.FeatureParams
+			if err = json.Unmarshal(data, &params); err != nil {
+				return err
+			}
+
+			return cliCtx.PrintOutput(params)
+		},
+	}
+}

--- a/featuremanager/client/cli/query.go
+++ b/featuremanager/client/cli/query.go
@@ -25,6 +25,7 @@ func GetQueryCmd(cdc *codec.Codec) *cobra.Command {
 		client.GetCommands(
 			GetTargetFeature(cdc),
 			GetAllFeatures(cdc),
+			GetAllSupportedFeatures(cdc),
 		)...,
 	)
 
@@ -84,7 +85,7 @@ func GetAllFeatures(cdc *codec.Codec) *cobra.Command {
 		Short: "show the current featuremanager parameters information in proposal",
 		Long: strings.TrimSpace(
 			fmt.Sprintf(
-				`Query values set as chain manager parameters.
+				`Query values set as feature manager parameters.
 Example:
 $ %s query featuremanager all-features
 `,
@@ -102,6 +103,42 @@ $ %s query featuremanager all-features
 			}
 
 			var params types.FeatureParams
+			if err = json.Unmarshal(data, &params); err != nil {
+				return err
+			}
+
+			return cliCtx.PrintOutput(params)
+		},
+	}
+}
+
+// GetAllSupportedFeatures implements the supported-features query command.
+func GetAllSupportedFeatures(cdc *codec.Codec) *cobra.Command {
+	//nolint: exhaustivestruct
+	return &cobra.Command{
+		Use:   "supported-features",
+		Args:  cobra.NoArgs,
+		Short: "show the current featuremanager supported features",
+		Long: strings.TrimSpace(
+			fmt.Sprintf(
+				`Query all supported features in feature manager.
+Example:
+$ %s query featuremanager supported-features
+`,
+				version.ClientName,
+			),
+		),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cliCtx := context.NewCLIContext().WithCodec(cdc)
+
+			route := fmt.Sprintf("custom/%s/%s", types.QuerierRoute, types.QuerySupportedFeatures)
+
+			data, _, err := cliCtx.QueryWithData(route, nil)
+			if err != nil {
+				return err
+			}
+
+			var params types.FeatureSupport
 			if err = json.Unmarshal(data, &params); err != nil {
 				return err
 			}

--- a/featuremanager/client/cli/tx.go
+++ b/featuremanager/client/cli/tx.go
@@ -1,0 +1,127 @@
+package cli
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/client/context"
+	"github.com/cosmos/cosmos-sdk/codec"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/maticnetwork/heimdall/featuremanager/types"
+	"github.com/maticnetwork/heimdall/helper"
+	hmTypes "github.com/maticnetwork/heimdall/types"
+	"github.com/maticnetwork/heimdall/version"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+var logger = helper.Logger.With("module", "featuremanager/client/cli")
+
+// GetTxCmd returns the transaction commands for this module.
+func GetTxCmd(cdc *codec.Codec, pcmds []*cobra.Command) *cobra.Command {
+	govTxCmd := &cobra.Command{
+		Use:                types.ModuleName,
+		Short:              "Featuremanager transactions subcommands",
+		DisableFlagParsing: true,
+		RunE:               client.ValidateCmd,
+	}
+
+	cmdSubmitProp := GetCmdSubmitProposal(cdc)
+	for _, pcmd := range pcmds {
+		cmdSubmitProp.AddCommand(client.PostCommands(pcmd)[0])
+	}
+
+	govTxCmd.AddCommand(client.PostCommands(
+		cmdSubmitProp,
+	)...)
+
+	return govTxCmd
+}
+
+// GetCmdSubmitProposal implements a command handler for submitting a feature change
+// proposal transaction.
+func GetCmdSubmitProposal(cdc *codec.Codec) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "feature-change [proposal-file]",
+		Args:  cobra.ExactArgs(1),
+		Short: "Submit a feature change proposal",
+		Long: strings.TrimSpace(
+			fmt.Sprintf(`Submit a feature change proposal along with an initial deposit.
+The proposal details must be supplied via a JSON file. For values that contains
+objects, only non-empty fields will be updated.
+
+IMPORTANT: Currently feature change changes are evaluated but not validated, so it is
+very important that any "value" change is valid (ie. correct type and within bounds)
+for its respective parameter, eg. "MaxValidators" should be an integer and not a decimal.
+
+Proper vetting of a feature change proposal should prevent this from happening
+(no deposits should occur during the governance process), but it should be noted
+regardless.
+
+Example:
+$ %s tx featuremanager feature-change <path/to/proposal.json> --validator-id <validator_id> --chain-id <chain_id>
+
+Where proposal.json contains:
+
+{
+  "title": "Feature-X Change",
+  "description": "Add feature-x",
+  "changes": [
+    {
+      "value": {
+		"feature_param_map": {
+			"feature_x" : {
+				"is_open": false,
+				int_conf: {},
+				string_conf: {}
+			}
+		}
+	  }
+    }
+  ],
+  "deposit": [
+    {
+      "denom": "btt",
+      "amount": "1000000000000000000" 
+    }
+  ]
+}
+`,
+				version.ClientName,
+			),
+		),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cliCtx := context.NewCLIContext().WithCodec(cdc)
+
+			proposal, err := ParseFeatureChangeProposalJSON(cdc, args[0])
+			if err != nil {
+				return err
+			}
+
+			validatorID := viper.GetUint64(FlagValidatorID)
+			if validatorID == 0 {
+				return fmt.Errorf("valid validator ID required")
+			}
+
+			from := helper.GetFromAddress(cliCtx)
+			content := types.NewFeatureChangeProposal(proposal.Title, proposal.Description, proposal.Changes.ToFeatureChanges())
+
+			// create submit proposal
+			msg := types.NewMsgSubmitProposal(content, proposal.Deposit, from, hmTypes.NewValidatorID(validatorID))
+			if err := msg.ValidateBasic(); err != nil {
+				return err
+			}
+
+			return helper.BroadcastMsgsWithCLI(cliCtx, []sdk.Msg{msg})
+		},
+	}
+
+	cmd.Flags().Int(FlagValidatorID, 0, "--validator-id=<validator ID here>")
+
+	if err := cmd.MarkFlagRequired(FlagValidatorID); err != nil {
+		logger.Error("GetCmdSubmitProposal | MarkFlagRequired | FlagValidatorID", "Error", err)
+	}
+
+	return cmd
+}

--- a/featuremanager/client/rest/query.go
+++ b/featuremanager/client/rest/query.go
@@ -1,0 +1,73 @@
+package rest
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/cosmos/cosmos-sdk/client/context"
+	"github.com/cosmos/cosmos-sdk/types/rest"
+	"github.com/gorilla/mux"
+
+	"github.com/maticnetwork/heimdall/featuremanager/types"
+)
+
+// HTTP request handler to query the featuremanager params values.
+func queryTargetFeatureHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
+	return func(writer http.ResponseWriter, req *http.Request) {
+		cliCtx, isSuccess := rest.ParseQueryHeightOrReturnBadRequest(writer, cliCtx, req)
+		if !isSuccess {
+			return
+		}
+
+		vars := mux.Vars(req)
+		targetFeature, ok := vars["target-feature"]
+
+		if !ok {
+			err := fmt.Errorf("'%s' is not a valid feature", vars["target-feature"])
+			rest.WriteErrorResponse(writer, http.StatusBadRequest, err.Error())
+
+			return
+		}
+
+		// get query params
+		queryParams, err := cliCtx.Codec.MarshalJSON(types.QueryTargetFeatureParam{
+			TargetFeature: targetFeature,
+		})
+		if err != nil {
+			return
+		}
+
+		route := fmt.Sprintf("custom/%s/%s", types.QuerierRoute, types.QueryTargetFeature)
+
+		res, height, err := cliCtx.QueryWithData(route, queryParams)
+		if err != nil {
+			rest.WriteErrorResponse(writer, http.StatusInternalServerError, err.Error())
+
+			return
+		}
+
+		cliCtx = cliCtx.WithHeight(height)
+		rest.PostProcessResponse(writer, cliCtx, res)
+	}
+}
+
+func queryFeatureMapHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
+	return func(writer http.ResponseWriter, req *http.Request) {
+		cliCtx, ok := rest.ParseQueryHeightOrReturnBadRequest(writer, cliCtx, req)
+		if !ok {
+			return
+		}
+
+		route := fmt.Sprintf("custom/%s/%s", types.QuerierRoute, types.QueryFeatureMap)
+
+		res, height, err := cliCtx.QueryWithData(route, nil)
+		if err != nil {
+			rest.WriteErrorResponse(writer, http.StatusInternalServerError, err.Error())
+
+			return
+		}
+
+		cliCtx = cliCtx.WithHeight(height)
+		rest.PostProcessResponse(writer, cliCtx, res)
+	}
+}

--- a/featuremanager/client/rest/rest.go
+++ b/featuremanager/client/rest/rest.go
@@ -1,0 +1,13 @@
+package rest
+
+import (
+	"github.com/cosmos/cosmos-sdk/client/context"
+	"github.com/gorilla/mux"
+)
+
+// RegisterRoutes - Central function to define routes that get registered by the main application
+// RegisterRoutes registers the auth module REST routes.
+func RegisterRoutes(cliCtx context.CLIContext, r *mux.Router) {
+	r.HandleFunc("/featuremanager/target-feature/{target-feature}", queryTargetFeatureHandlerFn(cliCtx)).Methods("GET")
+	r.HandleFunc("/featuremanager/feature-map", queryFeatureMapHandlerFn(cliCtx)).Methods("GET")
+}

--- a/featuremanager/handler.go
+++ b/featuremanager/handler.go
@@ -1,0 +1,33 @@
+package featuremanager
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/maticnetwork/heimdall/featuremanager/types"
+)
+
+func NewHandler(keeper Keeper) sdk.Handler {
+	return func(ctx sdk.Context, msg sdk.Msg) sdk.Result {
+		ctx = ctx.WithEventManager(sdk.NewEventManager())
+
+		switch msg := msg.(type) {
+		case types.MsgSubmitProposal:
+			return handleMsgSubmitProposal(ctx, keeper, msg)
+
+		default:
+			return sdk.ErrTxDecode("Invalid message in checkpoint module").Result()
+		}
+	}
+}
+
+// handleMsgSubmitProposal will check the proposal format,
+// the proposal content should be checked in side_handler.
+func handleMsgSubmitProposal(ctx sdk.Context, _ Keeper, msg types.MsgSubmitProposal) sdk.Result {
+	// check content format
+	if err := msg.ValidateBasic(); err != nil {
+		return err.Result()
+	}
+
+	return sdk.Result{
+		Events: ctx.EventManager().Events(),
+	}
+}

--- a/featuremanager/keeper.go
+++ b/featuremanager/keeper.go
@@ -74,7 +74,7 @@ func (k Keeper) HasFeature(feature string) bool {
 // Params
 
 // SetParams sets the featuremanager module's parameters.
-func (k Keeper) SeFeatureParams(ctx sdk.Context, params types.FeatureParams) error {
+func (k Keeper) SetFeatureParams(ctx sdk.Context, params types.FeatureParams) error {
 	k.paramSpace.SetParamSet(ctx, &params)
 
 	return nil
@@ -85,6 +85,39 @@ func (k Keeper) GetFeatureParams(ctx sdk.Context) (params types.FeatureParams) {
 	defer func() {
 		if err := recover(); err != nil {
 			params = types.DefaultFeatureParams()
+		}
+	}()
+	k.paramSpace.GetParamSet(ctx, &params)
+
+	return
+}
+
+// -----------------------------------------------------------------------------
+// Supported Features.
+
+// AddSupportedFeature add the featuremanager module's supported features.
+func (k Keeper) AddSupportedFeature(ctx sdk.Context, feature string) error {
+	supportedMap := types.FeatureSupport{
+		FeatureSupportMap: map[string]bool{
+			feature: true,
+		},
+	}
+
+	supportedMapRawData, err := k.cdc.MarshalJSON(supportedMap)
+	if err != nil {
+		return err
+	}
+
+	err = k.paramSpace.Update(ctx, types.KeySupportFeature, supportedMapRawData)
+
+	return err
+}
+
+// GetSupportedFeature gets the featuremanager module's all supported features.
+func (k Keeper) GetSupportedFeature(ctx sdk.Context) (params types.FeatureSupport) {
+	defer func() {
+		if err := recover(); err != nil {
+			params = types.DefaultFeatureSupport()
 		}
 	}()
 	k.paramSpace.GetParamSet(ctx, &params)

--- a/featuremanager/keeper.go
+++ b/featuremanager/keeper.go
@@ -1,0 +1,93 @@
+package featuremanager
+
+import (
+	"github.com/cosmos/cosmos-sdk/codec"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/maticnetwork/heimdall/featuremanager/types"
+	"github.com/maticnetwork/heimdall/gov"
+	"github.com/maticnetwork/heimdall/params/subspace"
+	"github.com/tendermint/tendermint/libs/log"
+)
+
+// Keeper stores all related data.
+type Keeper struct {
+	cdc *codec.Codec
+	// codespace
+	codespace sdk.CodespaceType
+
+	// gov keeper to handle subprocess of related proposal
+	govKeeper gov.Keeper
+
+	featureTable map[string]bool
+
+	// param space
+	paramSpace subspace.Subspace
+}
+
+// NewKeeper create new keeper.
+func NewKeeper(
+	cdc *codec.Codec,
+	paramSpace subspace.Subspace,
+	govKeeper gov.Keeper,
+	codespace sdk.CodespaceType,
+) Keeper {
+	// create keeper
+	keeper := Keeper{
+		cdc:          cdc,
+		paramSpace:   paramSpace.WithKeyTable(types.ParamKeyTable()),
+		govKeeper:    govKeeper,
+		featureTable: make(map[string]bool),
+		codespace:    codespace,
+	}
+	keeper.RegistreFeature()
+
+	return keeper
+}
+
+// Codespace returns the codespace.
+func (k Keeper) Codespace() sdk.CodespaceType {
+	return k.codespace
+}
+
+// Logger returns a module-specific logger.
+func (k Keeper) Logger(ctx sdk.Context) log.Logger {
+	return ctx.Logger().With("module", types.ModuleName)
+}
+
+func (k Keeper) addFeature(feature string) {
+	k.featureTable[feature] = true
+}
+
+// RegistreFeature keeps all adden features to vote for change.
+func (k Keeper) RegistreFeature() {
+	// all new type of features should be registered here.
+	k.addFeature("feature-x")
+}
+
+func (k Keeper) HasFeature(feature string) bool {
+	_, ok := k.featureTable[feature]
+
+	return ok
+}
+
+// -----------------------------------------------------------------------------
+// Params
+
+// SetParams sets the featuremanager module's parameters.
+func (k Keeper) SeFeatureParams(ctx sdk.Context, params types.FeatureParams) error {
+	k.paramSpace.SetParamSet(ctx, &params)
+
+	return nil
+}
+
+// GetParams gets the featuremanager module's parameters.
+func (k Keeper) GetFeatureParams(ctx sdk.Context) (params types.FeatureParams) {
+	defer func() {
+		if err := recover(); err != nil {
+			params = types.DefaultFeatureParams()
+		}
+	}()
+	k.paramSpace.GetParamSet(ctx, &params)
+
+	return
+}

--- a/featuremanager/module.go
+++ b/featuremanager/module.go
@@ -1,0 +1,139 @@
+package featuremanager
+
+import (
+	"encoding/json"
+
+	"github.com/cosmos/cosmos-sdk/client/context"
+	"github.com/cosmos/cosmos-sdk/codec"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/module"
+	"github.com/gorilla/mux"
+
+	"github.com/maticnetwork/heimdall/featuremanager/client/cli"
+	"github.com/maticnetwork/heimdall/featuremanager/client/rest"
+	"github.com/maticnetwork/heimdall/featuremanager/types"
+	hmTypes "github.com/maticnetwork/heimdall/types"
+	hmModule "github.com/maticnetwork/heimdall/types/module"
+	"github.com/spf13/cobra"
+	abci "github.com/tendermint/tendermint/abci/types"
+)
+
+var (
+	_ module.AppModule             = AppModule{}
+	_ module.AppModuleBasic        = AppModuleBasic{}
+	_ hmModule.HeimdallModuleBasic = AppModule{}
+)
+
+// AppModuleBasic defines the basic application module.
+type AppModuleBasic struct{}
+
+// Name returns the auth module's name.
+func (AppModuleBasic) Name() string {
+	return types.ModuleName
+}
+
+// RegisterCodec registers the auth module's types for the given codec.
+func (AppModuleBasic) RegisterCodec(cdc *codec.Codec) {
+	types.RegisterCodec(cdc)
+}
+
+// DefaultGenesis default genesis state.
+func (AppModuleBasic) DefaultGenesis() json.RawMessage { return nil }
+
+// ValidateGenesis module validate genesis.
+func (AppModuleBasic) ValidateGenesis(_ json.RawMessage) error { return nil }
+
+// VerifyGenesis module.
+func (AppModuleBasic) VerifyGenesis(bz map[string]json.RawMessage) error { return nil }
+
+// RegisterRESTRoutes register rest routes.
+func (AppModuleBasic) RegisterRESTRoutes(ctx context.CLIContext, rtr *mux.Router) {
+	rest.RegisterRoutes(ctx, rtr)
+}
+
+// GetTxCmd get the root tx command of this module.
+func (a AppModuleBasic) GetTxCmd(cdc *codec.Codec) *cobra.Command {
+	return cli.GetTxCmd(cdc, nil)
+}
+
+// GetQueryCmd get the root query command of this module.
+func (AppModuleBasic) GetQueryCmd(cdc *codec.Codec) *cobra.Command {
+	return cli.GetQueryCmd(cdc)
+}
+
+// ____________________________________________________________________________
+// AppModule implements an application module for the checkpoint module.
+type AppModule struct {
+	AppModuleBasic
+
+	keeper Keeper
+}
+
+// NewAppModule creates a new AppModule object.
+func NewAppModule(keeper Keeper) AppModule {
+	return AppModule{
+		AppModuleBasic: AppModuleBasic{},
+		keeper:         keeper,
+	}
+}
+
+// InitGenesis performs genesis initialization.
+func (am AppModule) InitGenesis(ctx sdk.Context, data json.RawMessage) []abci.ValidatorUpdate {
+	return []abci.ValidatorUpdate{}
+}
+
+// Name returns the auth module's name.
+func (AppModule) Name() string {
+	return types.ModuleName
+}
+
+// RegisterInvariants performs a no-op.
+func (AppModule) RegisterInvariants(_ sdk.InvariantRegistry) {}
+
+// Route returns the message routing key for the auth module.
+func (AppModule) Route() string {
+	return types.RouterKey
+}
+
+// QuerierRoute returns the auth module's querier route name.
+func (AppModule) QuerierRoute() string {
+	return types.QuerierRoute
+}
+
+// NewHandler returns an sdk.Handler for the module.
+func (am AppModule) NewHandler() sdk.Handler {
+	return NewHandler(am.keeper)
+}
+
+// NewQuerierHandler returns the auth module sdk.Querier.
+func (am AppModule) NewQuerierHandler() sdk.Querier {
+	return NewQuerier(am.keeper)
+}
+
+// ExportGenesis returns the exported genesis state as raw bytes.
+func (am AppModule) ExportGenesis(ctx sdk.Context) json.RawMessage {
+	return nil
+}
+
+// BeginBlock returns the begin blocker for the auth module.
+func (AppModule) BeginBlock(_ sdk.Context, _ abci.RequestBeginBlock) {}
+
+// EndBlock returns the end blocker for the auth module. It returns no validator
+// updates.
+func (AppModule) EndBlock(_ sdk.Context, _ abci.RequestEndBlock) []abci.ValidatorUpdate {
+	return []abci.ValidatorUpdate{}
+}
+
+//
+// Side module
+//
+
+// NewSideTxHandler side tx handler.
+func (am AppModule) NewSideTxHandler() hmTypes.SideTxHandler {
+	return NewSideTxHandler(am.keeper)
+}
+
+// NewPostTxHandler side tx handler.
+func (am AppModule) NewPostTxHandler() hmTypes.PostTxHandler {
+	return NewPostTxHandler(am.keeper)
+}

--- a/featuremanager/querier.go
+++ b/featuremanager/querier.go
@@ -19,6 +19,9 @@ func NewQuerier(keeper Keeper) sdk.Querier {
 		case types.QueryFeatureMap:
 			return queryPropsoalChainParamMap(ctx, keeper)
 
+		case types.QuerySupportedFeatures:
+			return querySupportedFeatures(ctx, keeper)
+
 		default:
 			return nil, sdk.ErrUnknownRequest("unknown featuremanager query endpoint")
 		}
@@ -50,6 +53,15 @@ func queryTargetFeature(ctx sdk.Context, req abci.RequestQuery, keeper Keeper) (
 
 func queryPropsoalChainParamMap(ctx sdk.Context, keeper Keeper) ([]byte, sdk.Error) {
 	data, err := json.Marshal(keeper.GetFeatureParams(ctx))
+	if err != nil {
+		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
+	}
+
+	return data, nil
+}
+
+func querySupportedFeatures(ctx sdk.Context, keeper Keeper) ([]byte, sdk.Error) {
+	data, err := json.Marshal(keeper.GetSupportedFeature(ctx))
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
 	}

--- a/featuremanager/querier.go
+++ b/featuremanager/querier.go
@@ -1,0 +1,58 @@
+package featuremanager
+
+import (
+	"encoding/json"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	abci "github.com/tendermint/tendermint/abci/types"
+
+	"github.com/maticnetwork/heimdall/featuremanager/types"
+)
+
+// NewQuerier creates a querier for auth REST endpoints.
+func NewQuerier(keeper Keeper) sdk.Querier {
+	return func(ctx sdk.Context, path []string, req abci.RequestQuery) ([]byte, sdk.Error) {
+		switch path[0] {
+		case types.QueryTargetFeature:
+			return queryTargetFeature(ctx, req, keeper)
+
+		case types.QueryFeatureMap:
+			return queryPropsoalChainParamMap(ctx, keeper)
+
+		default:
+			return nil, sdk.ErrUnknownRequest("unknown featuremanager query endpoint")
+		}
+	}
+}
+
+func queryTargetFeature(ctx sdk.Context, req abci.RequestQuery, keeper Keeper) ([]byte, sdk.Error) {
+	var params types.QueryTargetFeatureParam
+	if err := keeper.cdc.UnmarshalJSON(req.Data, &params); err != nil && len(req.Data) != 0 {
+		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("failed to parse params", err.Error()))
+	}
+
+	res := keeper.GetFeatureParams(ctx).FeatureParamMap
+
+	rawData, ok := res[params.TargetFeature]
+	if !ok {
+		rawData = types.FeatureData{} //nolint: exhaustivestruct
+	}
+
+	feature := rawData.Plainify()
+
+	bz, err := json.Marshal(feature)
+	if err != nil {
+		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
+	}
+
+	return bz, nil
+}
+
+func queryPropsoalChainParamMap(ctx sdk.Context, keeper Keeper) ([]byte, sdk.Error) {
+	data, err := json.Marshal(keeper.GetFeatureParams(ctx))
+	if err != nil {
+		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
+	}
+
+	return data, nil
+}

--- a/featuremanager/side_handler.go
+++ b/featuremanager/side_handler.go
@@ -1,0 +1,118 @@
+package featuremanager
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/maticnetwork/heimdall/common"
+	"github.com/maticnetwork/heimdall/featuremanager/types"
+	"github.com/maticnetwork/heimdall/gov"
+	govTypes "github.com/maticnetwork/heimdall/gov/types"
+	hmTypes "github.com/maticnetwork/heimdall/types"
+	abci "github.com/tendermint/tendermint/abci/types"
+)
+
+func NewSideTxHandler(keeper Keeper) hmTypes.SideTxHandler {
+	return func(ctx sdk.Context, msg sdk.Msg) abci.ResponseDeliverSideTx {
+		ctx = ctx.WithEventManager(sdk.NewEventManager())
+
+		switch msg := msg.(type) {
+		case types.MsgSubmitProposal:
+			return SideHandleMsgSubmitProposal(ctx, keeper, msg)
+
+		default:
+			//nolint: exhaustivestruct
+			return abci.ResponseDeliverSideTx{
+				Code: uint32(sdk.CodeUnknownRequest),
+			}
+		}
+	}
+}
+
+// SideHandleMsgSubmitProposal will check whether the node support the target feature.
+func SideHandleMsgSubmitProposal(
+	ctx sdk.Context, keeper Keeper,
+	msg types.MsgSubmitProposal,
+) (result abci.ResponseDeliverSideTx) {
+	if err := msg.ValidateBasic(); err != nil {
+		result.Result = abci.SideTxResultType_No
+
+		return
+	}
+
+	if _, err := gov.GetValidValidator(ctx, keeper.govKeeper, msg.Proposer, msg.Validator); err != nil {
+		result.Result = abci.SideTxResultType_No
+
+		return
+	}
+
+	result.Result = abci.SideTxResultType_Yes
+
+	switch content := msg.Content.(type) {
+	case types.FeatureChangeProposal:
+	Changes:
+		for _, change := range content.Changes {
+			chagneMapStr := change.Value
+
+			var changeMap types.FeatureParams
+			err := keeper.cdc.UnmarshalJSON([]byte(chagneMapStr), &changeMap)
+			if err != nil {
+				result.Result = abci.SideTxResultType_No
+
+				break Changes
+			}
+
+			for key := range changeMap.FeatureParamMap {
+				if !keeper.HasFeature(key) {
+					result.Result = abci.SideTxResultType_No
+
+					break Changes
+				}
+			}
+		}
+
+	default:
+		result.Result = abci.SideTxResultType_No
+	}
+
+	return result
+}
+
+func NewPostTxHandler(keeper Keeper) hmTypes.PostTxHandler {
+	return func(ctx sdk.Context, msg sdk.Msg, sideTxResult abci.SideTxResultType) sdk.Result {
+		ctx = ctx.WithEventManager(sdk.NewEventManager())
+
+		switch msg := msg.(type) {
+		case types.MsgSubmitProposal:
+			return PostHandleMsgSubmitProposal(ctx, keeper, msg, sideTxResult)
+
+		default:
+			return sdk.ErrUnknownRequest("Unrecognized checkpoint Msg type").Result()
+		}
+	}
+}
+
+// PostHandleMsgSubmitProposal submit a proposal to gov to begin voting period.
+func PostHandleMsgSubmitProposal(ctx sdk.Context, keeper Keeper,
+	msg types.MsgSubmitProposal,
+	sideTxResult abci.SideTxResultType,
+) sdk.Result {
+	logger := keeper.Logger(ctx)
+
+	// skip handler if feature is not approved.
+	if sideTxResult != abci.SideTxResultType_Yes {
+		logger.Info("Skipping new feature proposal since side-tx didn't get yes votes")
+
+		return common.ErrSideTxValidation(keeper.Codespace()).Result()
+	}
+
+	// submit a feature-change-proposal to gov
+	logger.Info("Submitting feature-change-proposal to gov", "msg", msg)
+
+	proposal := govTypes.MsgSubmitProposal{
+		Content:        msg.Content,
+		InitialDeposit: msg.InitialDeposit,
+		Proposer:       msg.Proposer,
+		Validator:      msg.Validator,
+	}
+
+	return gov.HandleMsgFeatureChangeProposal(ctx, keeper.govKeeper, proposal)
+}

--- a/featuremanager/types/codec.go
+++ b/featuremanager/types/codec.go
@@ -1,0 +1,18 @@
+package types
+
+import "github.com/cosmos/cosmos-sdk/codec"
+
+// ModuleCdc module codec.
+var ModuleCdc *codec.Codec
+
+func init() {
+	ModuleCdc = codec.New()
+	RegisterCodec(ModuleCdc)
+	ModuleCdc.Seal()
+}
+
+// RegisterCodec registers all necessary param module types with a given codec.
+func RegisterCodec(cdc *codec.Codec) {
+	cdc.RegisterConcrete(MsgSubmitProposal{}, "featuremanager/MsgSubmitProposal", nil)
+	cdc.RegisterConcrete(FeatureChangeProposal{}, "featuremanager/FeatureChangeProposal", nil)
+}

--- a/featuremanager/types/content.go
+++ b/featuremanager/types/content.go
@@ -1,0 +1,59 @@
+package types
+
+import (
+	"fmt"
+	"strings"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+// Constants pertaining to a Content object.
+const (
+	MaxDescriptionLength int = 5000
+	MaxTitleLength       int = 140
+)
+
+// Content defines an interface that a proposal must implement. It contains
+// information such as the title and description along with the type and routing
+// information for the appropriate handler to process the proposal. Content can
+// have additional fields, which will handled by a proposal's Handler.
+type Content interface {
+	GetTitle() string
+	GetDescription() string
+	ProposalRoute() string
+	ProposalType() string
+	ValidateBasic() sdk.Error
+	String() string
+}
+
+// Handler defines a function that handles a proposal after it has passed the
+// governance process.
+type Handler func(ctx sdk.Context, content Content) sdk.Error
+
+// ValidateAbstract validates a proposal's abstract contents returning an error
+// if invalid.
+func ValidateAbstract(codespace sdk.CodespaceType, content Content) sdk.Error {
+	title := content.GetTitle()
+
+	if len(strings.TrimSpace(title)) == 0 {
+		return ErrInvalidProposalContent(codespace, "proposal title cannot be blank")
+	}
+
+	if len(title) > MaxTitleLength {
+		return ErrInvalidProposalContent(codespace, fmt.Sprintf(
+			"proposal title is longer than max length of %d", MaxTitleLength))
+	}
+
+	description := content.GetDescription()
+
+	if len(description) == 0 {
+		return ErrInvalidProposalContent(codespace, "proposal description cannot be blank")
+	}
+
+	if len(description) > MaxDescriptionLength {
+		return ErrInvalidProposalContent(codespace, fmt.Sprintf(
+			"proposal description is longer than max length of %d", MaxDescriptionLength))
+	}
+
+	return nil
+}

--- a/featuremanager/types/errors.go
+++ b/featuremanager/types/errors.go
@@ -1,0 +1,73 @@
+package types
+
+import (
+	"fmt"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+// Param module codespace constants.
+const (
+	DefaultCodespace sdk.CodespaceType = "feature"
+
+	CodeUnknownSubspace  sdk.CodeType = 1
+	CodeSettingParameter sdk.CodeType = 2
+	CodeEmptyData        sdk.CodeType = 3
+
+	CodeUnknownProposal          sdk.CodeType = 4
+	CodeInactiveProposal         sdk.CodeType = 5
+	CodeAlreadyActiveProposal    sdk.CodeType = 6
+	CodeAlreadyFinishedProposal  sdk.CodeType = 7
+	CodeAddressNotStaked         sdk.CodeType = 8
+	CodeInvalidContent           sdk.CodeType = 9
+	CodeInvalidProposalType      sdk.CodeType = 10
+	CodeInvalidVote              sdk.CodeType = 11
+	CodeInvalidGenesis           sdk.CodeType = 12
+	CodeInvalidProposalStatus    sdk.CodeType = 13
+	CodeProposalHandlerNotExists sdk.CodeType = 14
+)
+
+// ErrUnknownSubspace returns an unknown subspace error.
+func ErrUnknownSubspace(codespace sdk.CodespaceType, space string) sdk.Error {
+	return sdk.NewError(codespace, CodeUnknownSubspace, fmt.Sprintf("unknown subspace %s", space))
+}
+
+// ErrSettingParameter returns an error for failing to set a parameter.
+func ErrSettingParameter(codespace sdk.CodespaceType, key, value, msg string) sdk.Error {
+	return sdk.NewError(codespace, CodeSettingParameter, fmt.Sprintf(
+		"error setting parameter %s on %s: %s", value, key, msg))
+}
+
+// ErrEmptyChanges returns an error for empty parameter changes.
+func ErrEmptyChanges(codespace sdk.CodespaceType) sdk.Error {
+	return sdk.NewError(codespace, CodeEmptyData, "submitted parameter changes are empty")
+}
+
+// ErrEmptySubspace returns an error for an empty subspace.
+func ErrEmptySubspace(codespace sdk.CodespaceType) sdk.Error {
+	return sdk.NewError(codespace, CodeEmptyData, "parameter subspace is empty")
+}
+
+// ErrEmptyKey returns an error for when an empty key is given.
+func ErrEmptyKey(codespace sdk.CodespaceType) sdk.Error {
+	return sdk.NewError(codespace, CodeEmptyData, "parameter key is empty")
+}
+
+// ErrEmptyValue returns an error for when an empty key is given.
+func ErrEmptyValue(codespace sdk.CodespaceType) sdk.Error {
+	return sdk.NewError(codespace, CodeEmptyData, "parameter value is empty")
+}
+
+func ErrInvalidProposalContent(cs sdk.CodespaceType, msg string) sdk.Error {
+	return sdk.NewError(cs, CodeInvalidContent, fmt.Sprintf("invalid proposal content: %s", msg))
+}
+
+func ErrInvalidProposalType(codespace sdk.CodespaceType, proposalType string) sdk.Error {
+	return sdk.NewError(codespace, CodeInvalidProposalType, fmt.Sprintf(
+		"proposal type '%s' is not valid", proposalType))
+}
+
+func ErrNoProposalHandlerExists(codespace sdk.CodespaceType, content interface{}) sdk.Error {
+	return sdk.NewError(codespace, CodeProposalHandlerNotExists, fmt.Sprintf(
+		"'%T' does not have a corresponding handler", content))
+}

--- a/featuremanager/types/keys.go
+++ b/featuremanager/types/keys.go
@@ -1,0 +1,18 @@
+package types
+
+const (
+	// ModuleName is the name of the module.
+	ModuleName = "featuremanager"
+
+	// StoreKey is the store key string.
+	StoreKey = ModuleName
+
+	// RouterKey is the message route.
+	RouterKey = ModuleName
+
+	// QuerierRoute is the querier route.
+	QuerierRoute = ModuleName
+
+	// DefaultParamspace default name for parameter store.
+	DefaultParamspace = ModuleName
+)

--- a/featuremanager/types/msgs.go
+++ b/featuremanager/types/msgs.go
@@ -1,0 +1,45 @@
+package types
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	govTypes "github.com/maticnetwork/heimdall/gov/types"
+	"github.com/maticnetwork/heimdall/helper"
+	hmTypes "github.com/maticnetwork/heimdall/types"
+)
+
+var _ sdk.Msg = MsgSubmitProposal{}
+
+const (
+	TypeMsgSubmitProposal = "submit_feature_proposal"
+)
+
+// MsgSubmitProposal represents submit proposal message.
+type MsgSubmitProposal struct {
+	govTypes.MsgSubmitProposal //  Validator id
+}
+
+func (msg MsgSubmitProposal) Route() string { return RouterKey }
+func (msg MsgSubmitProposal) Type() string  { return TypeMsgSubmitProposal }
+
+// NewMsgSubmitProposal creates new submit proposal.
+func NewMsgSubmitProposal(
+	content Content,
+	initialDeposit sdk.Coins,
+	proposer hmTypes.HeimdallAddress,
+	validator hmTypes.ValidatorID,
+) MsgSubmitProposal {
+	return MsgSubmitProposal{
+		MsgSubmitProposal: govTypes.MsgSubmitProposal{
+			Content:        content,
+			InitialDeposit: initialDeposit,
+			Proposer:       proposer,
+			Validator:      validator,
+		},
+	}
+}
+
+// GetSideSignBytes returns side sign bytes.
+func (msg MsgSubmitProposal) GetSideSignBytes() []byte {
+	// stakeUpdate:(uint256 validatorId, uint256 nonce, uint256 newAmount)
+	return helper.AppendBytes32()
+}

--- a/featuremanager/types/params.go
+++ b/featuremanager/types/params.go
@@ -1,0 +1,96 @@
+package types
+
+import (
+	"fmt"
+
+	"github.com/maticnetwork/heimdall/params/subspace"
+)
+
+// Parameter keys.
+var (
+	KeyFeatureParams = []byte("FeatureParams")
+)
+
+// nolint
+type FeatureData struct {
+	IsOpen *bool `json:"is_open" yaml:"is_open"`
+
+	// extra data
+	IntConf    map[string]int    `json:"int_conf" yaml:"int_conf"`
+	StringConf map[string]string `json:"string_conf" yaml:"string_conf"`
+}
+
+// nolint
+type PlainFeatureData struct {
+	IsOpen bool `json:"is_open" yaml:"is_open"`
+
+	// extra data
+	IntConf    map[string]int    `json:"int_conf" yaml:"int_conf"`
+	StringConf map[string]string `json:"string_conf" yaml:"string_conf"`
+}
+
+func (fd FeatureData) Plainify() (pd PlainFeatureData) {
+	if fd.IsOpen != nil {
+		pd.IsOpen = *fd.IsOpen
+	}
+
+	pd.IntConf = fd.IntConf
+	pd.StringConf = fd.StringConf
+
+	return
+}
+
+func (pfd PlainFeatureData) String() string {
+	var ret string
+
+	ret += fmt.Sprintf(`
+	IsOpen: 					%v,
+	IntConf: 					%v,
+	StringConf:					%v
+	`,
+		pfd.IsOpen, pfd.IntConf, pfd.StringConf)
+
+	return ret
+}
+
+// nolint
+type FeatureParams struct {
+	FeatureParamMap map[string]FeatureData `json:"feature_param_map" yaml:"feature_param_map"`
+}
+
+// DefaultParams returns a default set of parameters.
+func DefaultFeatureParams() FeatureParams {
+	return FeatureParams{
+		FeatureParamMap: make(map[string]FeatureData),
+	}
+}
+
+func (fp *FeatureParams) ParamSetPairs() subspace.ParamSetPairs {
+	return subspace.ParamSetPairs{
+		{Key: KeyFeatureParams, Value: fp},
+	}
+}
+
+func (fp FeatureParams) String() string {
+	var ret string
+
+	for key, val := range fp.FeatureParamMap {
+		pVal := val.Plainify()
+
+		ret += fmt.Sprintf(`
+		[feature]: 				%s
+		IsOpen: 				%v,
+		IntConf: 				%v,
+		StringConf:				%v,				
+		`,
+			key, pVal.IsOpen, pVal.IntConf, pVal.StringConf)
+	}
+
+	return ret
+}
+
+// ParamKeyTable for auth module.
+func ParamKeyTable() subspace.KeyTable {
+	//nolint: exhaustivestruct
+	return subspace.NewKeyTable().RegisterParamSet(&FeatureParams{})
+}

--- a/featuremanager/types/params.go
+++ b/featuremanager/types/params.go
@@ -8,7 +8,8 @@ import (
 
 // Parameter keys.
 var (
-	KeyFeatureParams = []byte("FeatureParams")
+	KeyFeatureParams  = []byte("FeatureParams")
+	KeySupportFeature = []byte("SupportFeature")
 )
 
 // nolint
@@ -53,6 +54,7 @@ func (pfd PlainFeatureData) String() string {
 	return ret
 }
 
+// FeatureParams indicates feature config.
 // nolint
 type FeatureParams struct {
 	FeatureParamMap map[string]FeatureData `json:"feature_param_map" yaml:"feature_param_map"`
@@ -89,8 +91,43 @@ func (fp FeatureParams) String() string {
 	return ret
 }
 
+// FeatureSupport indicates current chain supported features via sidechannel.
+// nolint
+type FeatureSupport struct {
+	FeatureSupportMap map[string]bool `json:"feature_support_map" yaml:"feature_support_map"`
+}
+
+// DefaultFeatureSupport returns a default set of feature supported.
+func DefaultFeatureSupport() FeatureSupport {
+	return FeatureSupport{
+		FeatureSupportMap: make(map[string]bool),
+	}
+}
+
+func (fs *FeatureSupport) ParamSetPairs() subspace.ParamSetPairs {
+	return subspace.ParamSetPairs{
+		{Key: KeySupportFeature, Value: fs},
+	}
+}
+
+func (fs FeatureSupport) String() string {
+	var ret string
+
+	for key, val := range fs.FeatureSupportMap {
+		ret += fmt.Sprintf(`
+		[feature]: 				%s
+		IsSupported: 				%v,		
+		`,
+			key, val)
+	}
+
+	return ret
+}
+
 // ParamKeyTable for auth module.
 func ParamKeyTable() subspace.KeyTable {
 	//nolint: exhaustivestruct
-	return subspace.NewKeyTable().RegisterParamSet(&FeatureParams{})
+	return subspace.NewKeyTable().
+		RegisterParamSet(&FeatureParams{}).
+		RegisterParamSet(&FeatureSupport{})
 }

--- a/featuremanager/types/proposal.go
+++ b/featuremanager/types/proposal.go
@@ -1,0 +1,106 @@
+package types
+
+import (
+	"fmt"
+	"strings"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	govTypes "github.com/maticnetwork/heimdall/gov/types"
+)
+
+const (
+	// ProposalTypeChange defines the type for a FeatureChangeProposal.
+	ProposalTypeChange = "FeatureChange"
+)
+
+// Assert FeatureChangeProposal implements govtypes.Content at compile-time.
+var _ govTypes.Content = FeatureChangeProposal{}
+
+func init() {
+	govTypes.RegisterProposalType(ProposalTypeChange)
+	govTypes.RegisterProposalTypeCodec(FeatureChangeProposal{}, "heimdall/FeatureChangeProposal")
+}
+
+// FeatureChangeProposal defines a proposal which contains multiple parameter changes.
+type FeatureChangeProposal struct {
+	Title       string          `json:"title" yaml:"title"`
+	Description string          `json:"description" yaml:"description"`
+	Changes     []FeatureChange `json:"changes" yaml:"changes"`
+}
+
+func NewFeatureChangeProposal(title, description string, changes []FeatureChange) FeatureChangeProposal {
+	return FeatureChangeProposal{title, description, changes}
+}
+
+// GetTitle returns the title of a parameter change proposal.
+func (pcp FeatureChangeProposal) GetTitle() string { return pcp.Title }
+
+// GetDescription returns the description of a parameter change proposal.
+func (pcp FeatureChangeProposal) GetDescription() string { return pcp.Description }
+
+// GetDescription returns the routing key of a parameter change proposal.
+func (pcp FeatureChangeProposal) ProposalRoute() string { return RouterKey }
+
+// ProposalType returns the type of a parameter change proposal.
+func (pcp FeatureChangeProposal) ProposalType() string { return ProposalTypeChange }
+
+// ValidateBasic validates the parameter change proposal.
+func (pcp FeatureChangeProposal) ValidateBasic() sdk.Error {
+	err := govTypes.ValidateAbstract(DefaultCodespace, pcp)
+	if err != nil {
+		return err
+	}
+
+	return ValidateChanges(pcp.Changes)
+}
+
+// String implements the Stringer interface.
+func (pcp FeatureChangeProposal) String() string {
+	var builder strings.Builder
+
+	builder.WriteString(fmt.Sprintf(`Parameter Change Proposal:
+  Title:       %s
+  Description: %s
+  Changes:
+`, pcp.Title, pcp.Description))
+
+	for _, pc := range pcp.Changes {
+		builder.WriteString(fmt.Sprintf(`    Param Change:
+      Value:    %X
+`, pc.Value))
+	}
+
+	return builder.String()
+}
+
+// ParamChange defines a parameter change.
+type FeatureChange struct {
+	Value string `json:"value" yaml:"value"`
+}
+
+func NewFeatureChange(value string) FeatureChange {
+	return FeatureChange{value}
+}
+
+// String implements the Stringer interface.
+func (pc FeatureChange) String() string {
+	return fmt.Sprintf(`Param Change:
+  Value:    %X
+`, pc.Value)
+}
+
+// ValidateChange performs basic validation checks over a set of ParamChange. It
+// returns an error if any ParamChange is invalid.
+func ValidateChanges(changes []FeatureChange) sdk.Error {
+	if len(changes) == 0 {
+		return ErrEmptyChanges(DefaultCodespace)
+	}
+
+	for _, pc := range changes {
+		if len(pc.Value) == 0 {
+			return ErrEmptyValue(DefaultCodespace)
+		}
+	}
+
+	return nil
+}

--- a/featuremanager/types/querier.go
+++ b/featuremanager/types/querier.go
@@ -1,0 +1,19 @@
+package types
+
+// query endpoints supported by the chain-manager Querier.
+const (
+	QueryTargetFeature = "target-feature"
+	QueryFeatureMap    = "feature-map"
+)
+
+// QueryChainParams defines the params for querying accounts.
+type QueryTargetFeatureParam struct {
+	TargetFeature string
+}
+
+// NewQueryChainParams creates a new instance of NewQueryChainParams.
+func NewQueryTargeFeatureParams(targetFeature string) QueryTargetFeatureParam {
+	return QueryTargetFeatureParam{
+		TargetFeature: targetFeature,
+	}
+}

--- a/featuremanager/types/querier.go
+++ b/featuremanager/types/querier.go
@@ -2,8 +2,9 @@ package types
 
 // query endpoints supported by the chain-manager Querier.
 const (
-	QueryTargetFeature = "target-feature"
-	QueryFeatureMap    = "feature-map"
+	QueryTargetFeature     = "target-feature"
+	QueryFeatureMap        = "feature-map"
+	QuerySupportedFeatures = "supported-features"
 )
 
 // QueryChainParams defines the params for querying accounts.

--- a/featuremanager/util/util.go
+++ b/featuremanager/util/util.go
@@ -31,8 +31,10 @@ func InitFeatureConfig(paramSpace subspace.Subspace) {
 	featureManager.featureSpace = paramSpace
 }
 
+// GetFeature is used to get target feature config.
 func (m *FeatureConfig) GetFeature(ctx sdk.Context, feature string) (config featuremanagerTypes.PlainFeatureData) {
 	defer func() {
+		// if featureSpace cannot get FeatureParams, it will recover from here.
 		if err := recover(); err != nil {
 			config = featuremanagerTypes.PlainFeatureData{
 				IsOpen:     false,
@@ -50,6 +52,28 @@ func (m *FeatureConfig) GetFeature(ctx sdk.Context, feature string) (config feat
 		config = featuremanagerTypes.PlainFeatureData{}
 	} else {
 		config = rawData.Plainify()
+	}
+
+	return
+}
+
+// GetSupportedFeature is used to get whether the target feature is consensus supported feature.
+func (m *FeatureConfig) GetSupportedFeature(ctx sdk.Context, feature string) (isSupported bool) {
+	defer func() {
+		// if featureSpace cannot get FeatureSupport, it will recover from here.
+		if err := recover(); err != nil {
+			isSupported = false
+		}
+	}()
+
+	params := featuremanagerTypes.FeatureSupport{}
+	m.featureSpace.GetParamSet(ctx, &params)
+
+	res, ok := params.FeatureSupportMap[feature]
+	if !ok {
+		isSupported = false
+	} else {
+		isSupported = res
 	}
 
 	return

--- a/featuremanager/util/util.go
+++ b/featuremanager/util/util.go
@@ -1,0 +1,56 @@
+package util
+
+import (
+	"sync"
+
+	"github.com/maticnetwork/heimdall/params/subspace"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	featuremanagerTypes "github.com/maticnetwork/heimdall/featuremanager/types"
+)
+
+var (
+	featureConfigManagerOnce        sync.Once
+	featureConfigureManagerInstance *FeatureConfig
+)
+
+type FeatureConfig struct {
+	featureSpace subspace.Subspace
+}
+
+func GetFeatureConfig() *FeatureConfig {
+	featureConfigManagerOnce.Do(func() {
+		featureConfigureManagerInstance = new(FeatureConfig)
+	})
+
+	return featureConfigureManagerInstance
+}
+
+func InitFeatureConfig(paramSpace subspace.Subspace) {
+	featureManager := GetFeatureConfig()
+	featureManager.featureSpace = paramSpace
+}
+
+func (m *FeatureConfig) GetFeature(ctx sdk.Context, feature string) (config featuremanagerTypes.PlainFeatureData) {
+	defer func() {
+		if err := recover(); err != nil {
+			config = featuremanagerTypes.PlainFeatureData{
+				IsOpen:     false,
+				IntConf:    make(map[string]int),
+				StringConf: make(map[string]string),
+			}
+		}
+	}()
+
+	params := featuremanagerTypes.FeatureParams{}
+	m.featureSpace.GetParamSet(ctx, &params)
+
+	rawData, ok := params.FeatureParamMap[feature]
+	if !ok {
+		config = featuremanagerTypes.PlainFeatureData{}
+	} else {
+		config = rawData.Plainify()
+	}
+
+	return
+}

--- a/params/proposal_handler.go
+++ b/params/proposal_handler.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	featuremanagerTypes "github.com/maticnetwork/heimdall/featuremanager/types"
 	govtypes "github.com/maticnetwork/heimdall/gov/types"
 	"github.com/maticnetwork/heimdall/params/types"
 )
@@ -15,6 +16,9 @@ func NewParamChangeProposalHandler(k Keeper) govtypes.Handler {
 		case types.ParameterChangeProposal:
 			return handleParameterChangeProposal(ctx, k, c)
 
+		case featuremanagerTypes.FeatureChangeProposal:
+			return handleFeatureChangeProposal(ctx, k, c)
+
 		default:
 			errMsg := fmt.Sprintf("unrecognized param proposal content type: %T", c)
 			return sdk.ErrUnknownRequest(errMsg)
@@ -24,6 +28,11 @@ func NewParamChangeProposalHandler(k Keeper) govtypes.Handler {
 
 func handleParameterChangeProposal(ctx sdk.Context, k Keeper, p types.ParameterChangeProposal) sdk.Error {
 	for _, c := range p.Changes {
+		// featuremanagerModule should be changed via handleFeatureChangeProposal.
+		if c.Subspace == featuremanagerTypes.ModuleName {
+			continue
+		}
+
 		ss, ok := k.GetSubspace(c.Subspace)
 		if !ok {
 			return types.ErrUnknownSubspace(k.codespace, c.Subspace)
@@ -35,6 +44,28 @@ func handleParameterChangeProposal(ctx sdk.Context, k Keeper, p types.ParameterC
 
 		if err := ss.Update(ctx, []byte(c.Key), []byte(c.Value)); err != nil {
 			return types.ErrSettingParameter(k.codespace, c.Key, c.Value, err.Error())
+		}
+	}
+
+	return nil
+}
+
+func handleFeatureChangeProposal(ctx sdk.Context, keeper Keeper,
+	p featuremanagerTypes.FeatureChangeProposal,
+) sdk.Error {
+	for _, change := range p.Changes {
+		subspace, ok := keeper.GetSubspace(featuremanagerTypes.ModuleName)
+		if !ok {
+			return types.ErrUnknownSubspace(keeper.codespace, featuremanagerTypes.ModuleName)
+		}
+
+		keeper.Logger(ctx).Info(
+			fmt.Sprintf("update feature; value: %s", change.Value),
+		)
+
+		if err := subspace.Update(ctx, featuremanagerTypes.KeyFeatureParams, []byte(change.Value)); err != nil {
+			return types.ErrSettingParameter(keeper.codespace,
+				string(featuremanagerTypes.KeyFeatureParams), change.Value, err.Error())
 		}
 	}
 

--- a/params/subspace/subspace.go
+++ b/params/subspace/subspace.go
@@ -20,13 +20,17 @@ const (
 	// Special keys that contains Map.
 	ParamsWithMultiChains string = "ParamsWithMultiChains"
 	FeatureParams         string = "FeatureParams"
+	SupportFeature        string = "SupportFeature"
 )
 
+// hasMap is used for marshalling and unmarshaling for map.
 func hasMap(key string) bool {
 	switch key {
 	case ParamsWithMultiChains:
 		fallthrough
 	case FeatureParams:
+		fallthrough
+	case SupportFeature:
 		return true
 	}
 
@@ -218,6 +222,8 @@ func (s Subspace) Update(ctx sdk.Context, key []byte, param []byte) error {
 
 	switch string(key) {
 	case ParamsWithMultiChains:
+		fallthrough
+	case SupportFeature:
 		fallthrough
 	case FeatureParams:
 		inputData := reflect.New(ty).Interface()

--- a/params/subspace/subspace.go
+++ b/params/subspace/subspace.go
@@ -1,6 +1,7 @@
 package subspace
 
 import (
+	"encoding/json"
 	"reflect"
 
 	"github.com/cosmos/cosmos-sdk/codec"
@@ -15,7 +16,22 @@ const (
 
 	// TStoreKey is the string store key for the param transient store
 	TStoreKey = "transient_params"
+
+	// Special keys that contains Map.
+	ParamsWithMultiChains string = "ParamsWithMultiChains"
+	FeatureParams         string = "FeatureParams"
 )
+
+func hasMap(key string) bool {
+	switch key {
+	case ParamsWithMultiChains:
+		fallthrough
+	case FeatureParams:
+		return true
+	}
+
+	return false
+}
 
 // Individual parameter store for each keeper
 // Transient store persists for a block, so we use it for
@@ -85,7 +101,18 @@ func (s Subspace) transientStore(ctx sdk.Context) sdk.KVStore {
 func (s Subspace) Get(ctx sdk.Context, key []byte, ptr interface{}) {
 	store := s.kvStore(ctx)
 	bz := store.Get(key)
-	err := s.cdc.UnmarshalJSON(bz, ptr)
+
+	var err error
+
+	if hasMap(string(key)) {
+		err = json.Unmarshal(bz, ptr)
+		if err != nil {
+			err = s.cdc.UnmarshalJSON(bz, ptr)
+		}
+	} else {
+		err = s.cdc.UnmarshalJSON(bz, ptr)
+	}
+
 	if err != nil {
 		panic(err)
 	}
@@ -98,7 +125,18 @@ func (s Subspace) GetIfExists(ctx sdk.Context, key []byte, ptr interface{}) {
 	if bz == nil {
 		return
 	}
-	err := s.cdc.UnmarshalJSON(bz, ptr)
+
+	var err error
+
+	if hasMap(string(key)) {
+		err = json.Unmarshal(bz, ptr)
+		if err != nil {
+			err = s.cdc.UnmarshalJSON(bz, ptr)
+		}
+	} else {
+		err = s.cdc.UnmarshalJSON(bz, ptr)
+	}
+
 	if err != nil {
 		panic(err)
 	}
@@ -146,11 +184,20 @@ func (s Subspace) Set(ctx sdk.Context, key []byte, param interface{}) {
 
 	s.checkType(store, key, param)
 
-	bz, err := s.cdc.MarshalJSON(param)
+	var data []byte
+	var err error
+
+	if hasMap(string(key)) {
+		data, err = json.Marshal(param)
+	} else {
+		data, err = s.cdc.MarshalJSON(param)
+	}
+
 	if err != nil {
 		panic(err)
 	}
-	store.Set(key, bz)
+
+	store.Set(key, data)
 
 	tstore := s.transientStore(ctx)
 	tstore.Set(key, []byte{})
@@ -170,7 +217,9 @@ func (s Subspace) Update(ctx sdk.Context, key []byte, param []byte) error {
 	dest := reflect.New(ty).Interface()
 
 	switch string(key) {
-	case string("ParamsWithMultiChains"):
+	case ParamsWithMultiChains:
+		fallthrough
+	case FeatureParams:
 		inputData := reflect.New(ty).Interface()
 
 		err := s.cdc.UnmarshalJSON(param, inputData)

--- a/params/types/proposal.go
+++ b/params/types/proposal.go
@@ -52,7 +52,7 @@ func (pcp ParameterChangeProposal) ValidateBasic() sdk.Error {
 		return err
 	}
 
-	return ValidateChanges(pcp.Changes)
+	return ValidateParamChanges(pcp.Changes)
 }
 
 // String implements the Stringer interface.
@@ -98,7 +98,7 @@ func (pc ParamChange) String() string {
 
 // ValidateChange performs basic validation checks over a set of ParamChange. It
 // returns an error if any ParamChange is invalid.
-func ValidateChanges(changes []ParamChange) sdk.Error {
+func ValidateParamChanges(changes []ParamChange) sdk.Error {
 	if len(changes) == 0 {
 		return ErrEmptyChanges(DefaultCodespace)
 	}


### PR DESCRIPTION
This PR provides a new module called featuremanager, which is aimed to provide a solution to accept a hard fork logic to chain.

It provides a new type of transcation callled FeatureChangeProposal, which will be handled by featuremanager. Such transaction can initiate a proposal, which aims to change target feature configurations, to the community to vote on. If this proposal is accepted, target feature configuration will be changed. Thus, the hard fork logic that relies on these configuration can be safely applied to chain.