### PR TITLE
add(core): eth finalized block

### DIFF
--- a/bridge/setu/listener/heimdall.go
+++ b/bridge/setu/listener/heimdall.go
@@ -3,13 +3,13 @@ package listener
 import (
 	"context"
 	"encoding/json"
+	"math/big"
 	"strconv"
 	"sync"
 	"sync/atomic"
 	"time"
 
 	"github.com/RichardKnop/machinery/v1/tasks"
-	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/maticnetwork/heimdall/bridge/setu/util"
 	"github.com/maticnetwork/heimdall/helper"
 
@@ -54,7 +54,7 @@ func (hl *HeimdallListener) Start() error {
 
 	hl.Logger.Info("Start polling for events", "pollInterval", pollInterval)
 
-	go hl.StartPolling(headerCtx, pollInterval, false)
+	go hl.StartPolling(headerCtx, pollInterval, false, nil)
 
 	go hl.StartPollingEventRecord(headerCtx, pollInterval, false)
 
@@ -62,13 +62,14 @@ func (hl *HeimdallListener) Start() error {
 }
 
 // ProcessHeader -
-func (hl *HeimdallListener) ProcessHeader(*types.Header) {
+func (hl *HeimdallListener) ProcessHeader(header *blockHeader) {
 }
 
 // StartPolling - starts polling for heimdall events
 // needAlign is used to decide whether the ticker is align to 1970 UTC.
 // if true, the ticker will always tick as it begins at 1970 UTC.
-func (hl *HeimdallListener) StartPolling(ctx context.Context, pollInterval time.Duration, needAlign bool) {
+func (hl *HeimdallListener) StartPolling(ctx context.Context, pollInterval time.Duration, needAlign bool,
+	number *big.Int) {
 	// How often to fire the passed in function in second
 	interval := pollInterval
 	firstInterval := interval

--- a/bridge/setu/listener/maticchain.go
+++ b/bridge/setu/listener/maticchain.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/RichardKnop/machinery/v1/tasks"
-	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/maticnetwork/heimdall/helper"
 )
 
@@ -34,16 +33,9 @@ func (ml *MaticChainListener) Start() error {
 	// start header process
 	go ml.StartHeaderProcess(headerCtx)
 
-	// subscribe to new head
-	subscription, err := ml.contractConnector.MaticChainClient.SubscribeNewHead(ctx, ml.HeaderChannel)
-	if err != nil {
-		// start go routine to poll for new header using client object
-		ml.Logger.Info("Start polling for header blocks", "pollInterval", helper.GetConfig().CheckpointerPollInterval)
-		go ml.StartPolling(ctx, helper.GetConfig().CheckpointerPollInterval, true)
-	} else {
-		// start go routine to listen new header using subscription
-		go ml.StartSubscription(ctx, subscription)
-	}
+	ml.Logger.Info("Start polling for header blocks", "pollInterval", helper.GetConfig().CheckpointerPollInterval)
+
+	go ml.StartPolling(ctx, helper.GetConfig().CheckpointerPollInterval, true, nil)
 
 	// subscribed to new head
 	ml.Logger.Info("Subscribed to new head")
@@ -52,7 +44,8 @@ func (ml *MaticChainListener) Start() error {
 }
 
 // ProcessHeader - process headerblock from maticchain
-func (ml *MaticChainListener) ProcessHeader(newHeader *types.Header) {
+func (ml *MaticChainListener) ProcessHeader(newBlockHeader *blockHeader) {
+	newHeader := newBlockHeader.header
 	ml.Logger.Debug("New block detected", "blockNumber", newHeader.Number)
 	// Marshall header block and publish to queue
 	headerBytes, err := newHeader.MarshalJSON()

--- a/bridge/setu/util/common.go
+++ b/bridge/setu/util/common.go
@@ -570,6 +570,17 @@ func GetDynamicCheckpointFeature(cliCtx cliContext.CLIContext) (*featureManagerT
 	return GetTargetFeatureConfig(cliCtx, featureManagerTypes.DynamicCheckpoint)
 }
 
+func GetFinalizedEthOpen(cliCtx cliContext.CLIContext) bool {
+	feature, err := GetTargetFeatureConfig(cliCtx, featureManagerTypes.FinalizedEth)
+	if err != nil {
+		logger.Error("Error fetching finalized root chain feature", "err", err)
+
+		return false
+	}
+
+	return feature.IsOpen
+}
+
 // GetTargetFeatureConfig return target feature config.
 func GetTargetFeatureConfig(
 	cliCtx cliContext.CLIContext, feature string,

--- a/checkpoint/client/cli/tx.go
+++ b/checkpoint/client/cli/tx.go
@@ -229,7 +229,12 @@ func SendCheckpointACKTx(cdc *codec.Codec) *cobra.Command {
 			var rootChainAddress common.Address
 			switch rootChain {
 			case hmTypes.RootChainTypeEth, hmTypes.RootChainTypeBsc:
-				receipt, err = contractCallerObj.GetConfirmedTxReceipt(txHash.EthHash(), chainmanagerParams.MainchainTxConfirmations, rootChain)
+				finalizedEthOpen := false
+				if rootChain == hmTypes.RootChainTypeEth {
+					finalizedEthOpen = util.GetFinalizedEthOpen(cliCtx)
+				}
+				receipt, err = contractCallerObj.GetConfirmedTxReceipt(txHash.EthHash(),
+					chainmanagerParams.MainchainTxConfirmations, rootChain, finalizedEthOpen)
 				if err != nil || receipt == nil {
 					return errors.New("transaction is not confirmed yet. Please wait for sometime and try again")
 				}

--- a/clerk/querier.go
+++ b/clerk/querier.go
@@ -4,6 +4,9 @@ import (
 	"encoding/json"
 	"fmt"
 
+	featuremanagerTypes "github.com/maticnetwork/heimdall/featuremanager/types"
+	"github.com/maticnetwork/heimdall/featuremanager/util"
+
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	ethTypes "github.com/ethereum/go-ethereum/core/types"
@@ -100,18 +103,21 @@ func handleQueryRecordSequence(ctx sdk.Context, req abci.RequestQuery, keeper Ke
 	chainParams := keeper.chainKeeper.GetParams(ctx)
 	var receipt *ethTypes.Receipt
 	var err error
+
 	// get main tx receipt
 	switch params.RootChainType {
 	case hmTypes.RootChainTypeEth:
+		targetFeature := util.GetFeatureConfig().GetFeature(ctx, featuremanagerTypes.FinalizedEth)
+		finalizedEth := targetFeature.IsOpen
 		receipt, err = contractCallerObj.GetConfirmedTxReceipt(hmTypes.HexToHeimdallHash(params.TxHash).EthHash(),
-			chainParams.MainchainTxConfirmations, hmTypes.RootChainTypeEth)
+			chainParams.MainchainTxConfirmations, hmTypes.RootChainTypeEth, finalizedEth)
 	case hmTypes.RootChainTypeBsc:
 		bscChain, err := keeper.chainKeeper.GetChainParams(ctx, hmTypes.RootChainTypeBsc)
 		if err != nil {
 			return nil, sdk.ErrInternal(fmt.Sprintf("wrong chain type = " + params.RootChainType + "plealse pass correct chainType like bsc"))
 		}
 		receipt, err = contractCallerObj.GetConfirmedTxReceipt(hmTypes.HexToHeimdallHash(params.TxHash).EthHash(),
-			bscChain.TxConfirmations, hmTypes.RootChainTypeBsc)
+			bscChain.TxConfirmations, hmTypes.RootChainTypeBsc, false)
 	case hmTypes.RootChainTypeTron:
 		receipt, err = contractCallerObj.GetTronTransactionReceipt(hmTypes.HexToHeimdallHash(params.TxHash).TronHash().Hex())
 	default:

--- a/clerk/side_handler.go
+++ b/clerk/side_handler.go
@@ -5,6 +5,9 @@ import (
 	"math/big"
 	"strconv"
 
+	featuremanagerTypes "github.com/maticnetwork/heimdall/featuremanager/types"
+	"github.com/maticnetwork/heimdall/featuremanager/util"
+
 	ethCommon "github.com/ethereum/go-ethereum/common"
 
 	ethTypes "github.com/ethereum/go-ethereum/core/types"
@@ -66,10 +69,13 @@ func SideHandleMsgEventRecord(ctx sdk.Context, k Keeper, msg types.MsgEventRecor
 	var err error
 	// get main tx receipt
 	var contractAddress ethCommon.Address
+
 	switch msg.RootChainType {
 	case hmTypes.RootChainTypeEth:
+		targetFeature := util.GetFeatureConfig().GetFeature(ctx, featuremanagerTypes.FinalizedEth)
+		finalizedEth := targetFeature.IsOpen
 		receipt, err = contractCaller.GetConfirmedTxReceipt(msg.TxHash.EthHash(), params.MainchainTxConfirmations,
-			hmTypes.RootChainTypeEth)
+			hmTypes.RootChainTypeEth, finalizedEth)
 		if err != nil || receipt == nil {
 			return hmCommon.ErrorSideTx(k.Codespace(), common.CodeWaitFrConfirmation)
 		}
@@ -81,7 +87,7 @@ func SideHandleMsgEventRecord(ctx sdk.Context, k Keeper, msg types.MsgEventRecor
 			return hmCommon.ErrorSideTx(k.Codespace(), common.CodeWrongRootChainType)
 		}
 		receipt, err = contractCaller.GetConfirmedTxReceipt(msg.TxHash.EthHash(), bscChain.TxConfirmations,
-			hmTypes.RootChainTypeBsc)
+			hmTypes.RootChainTypeBsc, false)
 		if err != nil || receipt == nil {
 			return hmCommon.ErrorSideTx(k.Codespace(), common.CodeWaitFrConfirmation)
 		}

--- a/featuremanager/keeper.go
+++ b/featuremanager/keeper.go
@@ -64,6 +64,7 @@ func (k Keeper) RegisterFeature() {
 	k.addFeature("feature-x")
 	k.addFeature(types.DynamicCheckpoint)
 	k.addFeature(types.SupportMapMarshaling)
+	k.addFeature(types.FinalizedEth)
 }
 
 func (k Keeper) HasFeature(feature string) bool {

--- a/featuremanager/types/keys.go
+++ b/featuremanager/types/keys.go
@@ -20,4 +20,5 @@ const (
 const (
 	SupportMapMarshaling = "SupportMapMarshaling"
 	DynamicCheckpoint    = "DynamicCheckpoint"
+	FinalizedEth         = "FinalizedEth"
 )

--- a/go.mod
+++ b/go.mod
@@ -149,4 +149,4 @@ replace github.com/tendermint/tendermint => github.com/maticnetwork/tendermint v
 
 replace github.com/cosmos/cosmos-sdk => github.com/maticnetwork/cosmos-sdk v0.37.5-0.20220311095845-81690c6a53e7
 
-replace github.com/ethereum/go-ethereum => github.com/maticnetwork/bor v0.2.16
+replace github.com/ethereum/go-ethereum => github.com/maticnetwork/bor v0.2.18-0.20220922050621-c91d4ca1fa4f

--- a/go.sum
+++ b/go.sum
@@ -503,6 +503,8 @@ github.com/markbates/oncer v0.0.0-20181203154359-bf2de49a0be2/go.mod h1:Ld9puTsI
 github.com/markbates/safe v1.0.1/go.mod h1:nAqgmRi7cY2nqMc92/bSEeQA+R4OheNU2T1kNSCBdG0=
 github.com/maticnetwork/bor v0.2.16 h1:pz3MNdTotTWlcFXKnTSDolJ3VEmrYL+sqz6FsaWtJAQ=
 github.com/maticnetwork/bor v0.2.16/go.mod h1:tskr68Tlk2R6NLBQW2gaiQKx3BCdRvsGkcnhFUPKyh4=
+github.com/maticnetwork/bor v0.2.18-0.20220922050621-c91d4ca1fa4f h1:GJwlDTapZGPFhVNjflv2lOPSp0qB0p2PJ137qbaJRcY=
+github.com/maticnetwork/bor v0.2.18-0.20220922050621-c91d4ca1fa4f/go.mod h1:tskr68Tlk2R6NLBQW2gaiQKx3BCdRvsGkcnhFUPKyh4=
 github.com/maticnetwork/cosmos-sdk v0.37.5-0.20220311095845-81690c6a53e7 h1:8NoEtDFvY0r9KTow/jgEwOfTCPnXOs6MlEdUhRUQY78=
 github.com/maticnetwork/cosmos-sdk v0.37.5-0.20220311095845-81690c6a53e7/go.mod h1:uW55Ru86N5o3L8SVkVL1TPE+mV/WRM2la8sC3TR/Ajc=
 github.com/maticnetwork/tendermint v0.26.0-dev0.0.20220803122020-9c20f6000900 h1:mtI3GQCzvC5tRIGSUKo+PfS1FIUAGmMGXHUMxhPsV68=

--- a/helper/mocks/IContractCaller.go
+++ b/helper/mocks/IContractCaller.go
@@ -456,7 +456,7 @@ func (_m *IContractCaller) GetCheckpointSign(txHash common.Hash) ([]byte, []byte
 }
 
 // GetConfirmedTxReceipt provides a mock function with given fields: _a0, _a1, _a2
-func (_m *IContractCaller) GetConfirmedTxReceipt(_a0 common.Hash, _a1 uint64, _a2 string) (*types.Receipt, error) {
+func (_m *IContractCaller) GetConfirmedTxReceipt(_a0 common.Hash, _a1 uint64, _a2 string, _a3 bool) (*types.Receipt, error) {
 	ret := _m.Called(_a0, _a1, _a2)
 
 	var r0 *types.Receipt

--- a/staking/client/cli/tx.go
+++ b/staking/client/cli/tx.go
@@ -90,10 +90,10 @@ func SendValidatorJoinTx(cdc *codec.Codec) *cobra.Command {
 			if err != nil {
 				return err
 			}
-
+			finalizedEthOpen := util.GetFinalizedEthOpen(cliCtx)
 			// get main tx receipt
 			receipt, err := contractCallerObj.GetConfirmedTxReceipt(hmTypes.HexToHeimdallHash(txhash).EthHash(),
-				chainmanagerParams.MainchainTxConfirmations, hmTypes.RootChainTypeEth)
+				chainmanagerParams.MainchainTxConfirmations, hmTypes.RootChainTypeEth, finalizedEthOpen)
 			if err != nil || receipt == nil {
 				return errors.New("Transaction is not confirmed yet. Please wait for sometime and try again")
 			}


### PR DESCRIPTION
###  What does this PR do?
Add query eth finalized block to prevent transaction verification error when eth is forked.

###  Why are these changes required?
The eth2.0 finalized block may be more than 64 blocks away from the head block. At this time, it is not safe to use the original method to verify transactions on the eth chain.

###  This PR has been tested by:

* Unit Tests

* Manual Testing

###  Follow up
###  Extra details