### PR TITLE
fix: handle nil value in subspace.Get to prevent panic

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Validator node for Bittorrent Chain Network. It uses peppermint, customized [Ten
 
 ### Install from source 
 
-Make sure your have go1.11+ already installed
+Make sure your have go1.21+ already installed
 
 ### Install 
 ```bash 

--- a/auth/querier_test.go
+++ b/auth/querier_test.go
@@ -157,11 +157,19 @@ func (suite *QuerierTestSuite) TestQueryParams() {
 	require.Equal(t, uint64(8), params.TxSizeCostPerByte)
 
 	{
+		// When params are not set, querier should return zero values instead of panicking
 		happ := app.Setup(true)
 		ctx := happ.BaseApp.NewContext(true, abci.Header{})
 		querier := auth.NewQuerier(happ.AccountKeeper)
-		require.Panics(t, func() {
-			querier(ctx, path, req)
-		})
+		res, err = querier(ctx, path, req)
+		require.NoError(t, err)
+		require.NotNil(t, res)
+
+		var zeroParams types.Params
+		err4 := json.Unmarshal(res, &zeroParams)
+		require.NoError(t, err4)
+		// Params should be zero values when not initialized
+		require.Equal(t, uint64(0), zeroParams.MaxMemoCharacters)
+		require.Equal(t, uint64(0), zeroParams.TxSigLimit)
 	}
 }

--- a/chainmanager/querier_test.go
+++ b/chainmanager/querier_test.go
@@ -82,11 +82,18 @@ func (suite *QuerierTestSuite) TestQueryParams() {
 	require.Equal(t, defaultParams.ChainParams, params.ChainParams)
 
 	{
+		// When params are not set, querier should return zero values instead of panicking
 		rapp := app.Setup(true)
 		ctx := rapp.BaseApp.NewContext(true, abci.Header{})
 		querier := chainmanager.NewQuerier(rapp.ChainKeeper)
-		require.Panics(t, func() {
-			querier(ctx, path, req)
-		})
+		res, err = querier(ctx, path, req)
+		require.NoError(t, err)
+		require.NotNil(t, res)
+
+		var zeroParams types.Params
+		json.Unmarshal(res, &zeroParams)
+		// Params should be zero values when not initialized
+		require.Equal(t, uint64(0), zeroParams.MainchainTxConfirmations)
+		require.Equal(t, uint64(0), zeroParams.MaticchainTxConfirmations)
 	}
 }

--- a/params/subspace/subspace.go
+++ b/params/subspace/subspace.go
@@ -2,8 +2,9 @@ package subspace
 
 import (
 	"encoding/json"
-	"github.com/ethereum/go-ethereum/log"
 	"reflect"
+
+	"github.com/ethereum/go-ethereum/log"
 
 	"github.com/maticnetwork/heimdall/helper/fork"
 
@@ -122,6 +123,13 @@ func (s Subspace) transientStore(ctx sdk.Context) sdk.KVStore {
 func (s Subspace) Get(ctx sdk.Context, key []byte, ptr interface{}) {
 	store := s.kvStore(ctx)
 	bz := store.Get(key)
+
+	// If the key does not exist in store, return early without modifying ptr
+	// This allows ptr to keep its zero value (e.g., 0 for time.Duration)
+	// Callers can check if the value > 0 to determine if it was set
+	if bz == nil {
+		return
+	}
 
 	var err error
 


### PR DESCRIPTION
When a parameter key does not exist in store (e.g., newly added CheckpointPollInterval parameter on existing nodes), the Get method would panic with 'UnmarshalJSON cannot decode empty bytes'.

This fix returns early when bz is nil, allowing the ptr to keep its zero value. Callers can check if value > 0 to determine if it was set in the database, and fall back to config file defaults if needed.