### PR TITLE
recover the checkpointTimeout in handler

### DIFF
--- a/checkpoint/handler.go
+++ b/checkpoint/handler.go
@@ -238,7 +238,7 @@ func handleMsgCheckpointNoAck(ctx sdk.Context, msg types.MsgCheckpointNoAck, k K
 		tronMaxLength := tronDynamicFeature.IntConf["maxLength"]
 		checkpointTimeout, _ = helper.CalcCheckpointTimeout(tronMaxLength, checkpointPollInterval)
 	} else {
-		checkpointTimeout = checkpointPollInterval
+		checkpointTimeout = bufferTime
 	}
 
 	// Fetch last checkpoint from store


### PR DESCRIPTION
To maintain compatibility with previous code，recovery checkpointTimeout  when Tron dynamic checkpoints are not open