### PR TITLE
process CalcCheckpointTimeout when tronMaxLength or pollTime equals 0

### DIFF
--- a/bridge/setu/processor/checkpoint.go
+++ b/bridge/setu/processor/checkpoint.go
@@ -866,7 +866,11 @@ func (cp *CheckpointProcessor) checkIfNoAckIsRequired(checkpointContext *Checkpo
 		return false, uint64(index)
 	}
 	if isOpen {
-		checkpointTimeout, _ = helper.CalcCheckpointTimeout(tronMaxLength, checkpointPollInterval)
+		checkpointTimeout, err = helper.CalcCheckpointTimeout(tronMaxLength, checkpointPollInterval)
+		if err != nil {
+			cp.Logger.Error("failed to CalcCheckpointTimeout", "error", err)
+			return false, uint64(index)
+		}
 	} else {
 		checkpointTimeout = checkpointPollInterval
 	}

--- a/bridge/setu/util/common.go
+++ b/bridge/setu/util/common.go
@@ -457,7 +457,6 @@ func GetCheckpointParamsWithRetry(cliCtx cliContext.CLIContext) *checkpointTypes
 	logger.Error("Unexpected: exceeded retry loop without returning or exiting")
 
 	panic(errors.New("Failed to fetch checkpoint params"))
-	return nil
 }
 
 // GetBufferedCheckpoint return checkpoint from bueffer

--- a/checkpoint/types/params.go
+++ b/checkpoint/types/params.go
@@ -117,9 +117,5 @@ func (p Params) Validate() error {
 		return fmt.Errorf("ChildBlockInterval should be greater than zero")
 	}
 
-	if p.CheckpointPollInterval == 0 {
-		return fmt.Errorf("CheckpointPollInterval should be greater than zero")
-	}
-
 	return nil
 }

--- a/helper/util.go
+++ b/helper/util.go
@@ -896,7 +896,12 @@ func Hash(s []byte) ([]byte, error) {
 
 func CalcCheckpointTimeout(tronMaxLength int, pollTime time.Duration) (time.Duration, error) {
 	if pollTime <= 0 {
+		Logger.Error("pollTime should be greater than 0", "pollTime", pollTime)
 		return 0, errors.New("pollTime must be greater than 0")
+	}
+	if tronMaxLength <= 0 {
+		Logger.Error("tronMaxLength should be greater than 0", "tronMaxLength", tronMaxLength)
+		return 0, errors.New("tronMaxLength must be greater than 0")
 	}
 
 	timeForBttcBlocks := time.Duration(tronMaxLength)*BttcBlockInterval + time.Duration(tronMaxLength)/BttcSprintLength*(BttcFirstBlockIntervalInSprint-BttcBlockInterval)

--- a/helper/util_test.go
+++ b/helper/util_test.go
@@ -78,3 +78,19 @@ func TestCalcCheckpointTimeout2(t *testing.T) {
 	checkpointTimeout, _ := CalcCheckpointTimeout(tronMaxLength, pollTime)
 	require.Equal(t, 40*time.Minute, checkpointTimeout, "checkpointTimeout should match")
 }
+
+func TestCalcCheckpointTimeout3(t *testing.T) {
+	tronMaxLength := 0
+	pollTime := 5 * time.Minute
+	checkpointTimeout, err := CalcCheckpointTimeout(tronMaxLength, pollTime)
+	require.Equal(t, 0*time.Minute, checkpointTimeout, "checkpointTimeout should match")
+	require.True(t, err != nil)
+}
+
+func TestCalcCheckpointTimeout4(t *testing.T) {
+	tronMaxLength := 1024
+	pollTime := 0 * time.Minute
+	checkpointTimeout, err := CalcCheckpointTimeout(tronMaxLength, pollTime)
+	require.Equal(t, 0*time.Minute, checkpointTimeout, "checkpointTimeout should match")
+	require.True(t, err != nil)
+}


### PR DESCRIPTION
1. if  CalcCheckpointTimeout returns error then return false in checkIfNoAckIsRequired function
2. don't check CheckpointPollInterval in Validate()
3. remove unreachable "return" in GetCheckpointParamsWithRetry function